### PR TITLE
Adapt the tests to the 3.17 refacto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "rocket-scripts",
-  "version": "1.0.0",
+  "name": "wp-rocket-scripts",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rocket-scripts",
-      "version": "1.0.0",
+      "name": "wp-rocket-scripts",
+      "version": "1.0.4",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "0.23.0",

--- a/test/BeaconLcp.test.js
+++ b/test/BeaconLcp.test.js
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import BeaconLcp from '../src/BeaconLcp.js';
+import node_fetch from 'node-fetch';
+global.fetch = node_fetch;
+
+describe('BeaconManager', function() {
+    let beacon;
+    const config = { nonce: 'test', url: 'http://example.com', is_mobile: false };
+    beforeEach(function() {
+        beacon = new BeaconLcp(config);
+    });
+
+    describe('#constructor()', function() {
+        it('should initialize with the given config', function() {
+            assert.deepStrictEqual(beacon.config, config);
+        });
+    });
+
+    describe('#_isDuplicateImage()', function() {
+        it('should return true for a duplicate image', function() {
+            beacon.performanceImages = [{ src: 'http://example.com/image.jpg', nodeName:'img', type:'img' }];
+            const image = { src: 'http://example.com/image.jpg', nodeName:'img', type:'img' };
+            assert.strictEqual(beacon._isDuplicateImage(image), true);
+        });
+
+        it('should return false for a unique image', function() {
+            beacon.performanceImages = [{ src: 'http://example.com/image.jpg', nodeName:'img', type:'img' }];
+            const image = { src: 'http://example.com/unique.jpg', nodeName:'img', type:'img' };
+            assert.strictEqual(beacon._isDuplicateImage(image), false);
+        });
+    });
+
+});

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import BeaconUtils from '../src/Utils.js';
+import node_fetch from 'node-fetch';
+global.fetch = node_fetch;
+
+describe('BeaconManager', function() {
+
+    describe('#isIntersecting', function() {
+        beforeEach(function () {
+            // Mock viewport size
+            global.window = {
+                innerWidth: 1024,
+                innerHeight: 768
+            };
+        });
+
+        it('should return true for a rectangle fully within the viewport', function () {
+            const rect = {top: 100, left: 100, bottom: 200, right: 200};
+            assert.strictEqual(BeaconUtils.isIntersecting(rect), true);
+        });
+
+        it('should return false for a rectangle entirely above the viewport', function () {
+            const rect = {top: -500, left: 100, bottom: -400, right: 200};
+            assert.strictEqual(BeaconUtils.isIntersecting(rect), false);
+        });
+
+        it('should return false for a rectangle entirely below the viewport', function () {
+            const rect = {top: 800, left: 100, bottom: 900, right: 200};
+            assert.strictEqual(BeaconUtils.isIntersecting(rect), false);
+        });
+
+        it('should return false for a rectangle entirely to the left of the viewport', function () {
+            const rect = {top: 100, left: -500, bottom: 200, right: -400};
+            assert.strictEqual(BeaconUtils.isIntersecting(rect), false);
+        });
+
+        it('should return false for a rectangle entirely to the right of the viewport', function () {
+            const rect = {top: 100, left: 1100, bottom: 200, right: 1200};
+            assert.strictEqual(BeaconUtils.isIntersecting(rect), false);
+        });
+    });
+
+    describe('#isPageCached', function() {
+
+        it('should return true when the page is cached', function() {
+
+            global.document ={
+                documentElement: {
+                    nextSibling: {
+                        data:'<!--Debug: cached-->'
+                    }
+                }
+            };
+
+            assert.strictEqual(BeaconUtils.isPageCached(), true);
+        });
+
+        it('should return false when the page is not cached', function() {
+            global.document ={
+                documentElement: {
+                    nextSibling: {
+                        data:'test'
+                    }
+                }
+            };
+            assert.strictEqual(BeaconUtils.isPageCached(), false);
+        });
+    });
+
+});


### PR DESCRIPTION
# Description

Fixes #11

## Documentation

### User documentation

NA

### Technical documentation

The 3.17 refacto changed the file organization with various classes and files. The tests were not adapted.
I did not modify the covered stuff, but just adapted the tests to the new code.
Note that there are test modifications about teh saveToDb AJAX call payload, as it changed with 3.17 refacto. This is the only test modification other than just naming/files/class

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
NA

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

![image](https://github.com/user-attachments/assets/817738be-2824-4d9b-8c72-808903b62edc)


## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

