### PR TITLE
Move main from index.js to BeaconEntryPoint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 /.idea
-/src/BeaconEntryPoint.js
 /test
 /.github

--- a/README.md
+++ b/README.md
@@ -26,43 +26,38 @@ npm run build
 
 This is to build both minified and not minified versions.
 
-# Updating WP Rocket
+## Updating WP Rocket
 
-## How to import changes from rocket-scripts
+### How to import changes from rocket-scripts
 
 The following steps must be followed when you need to test a new version of the scripts within WP Rocket plugin, or to submit a new version into WP Rocket through a PR.
 
 1. Create a branch and PR for your changes in this repository.
 2. Check out wp rocket plugin on branch develop (or a dedicated branch for the issue to test if needed)
 3. Edit `package.json` inside WP Rocket plugin repository to change the targeted version of wp-rocket-scripts:
-```
-"wp-rocket-scripts": "github:wp-media/rocket-scripts#branch-name",
-```
+    ```
+    "wp-rocket-scripts": "github:wp-media/rocket-scripts#branch-name",
+    ```
 
-This syntax allows to target a specific branch as dependency. For instance:
+    This syntax allows to target a specific branch as dependency. For instance:
 
-```
-"wp-rocket-scripts": "github:wp-media/rocket-scripts#enhancement/6741-adjust-beacon-timeout",
-```
-
+    ```
+    "wp-rocket-scripts": "github:wp-media/rocket-scripts#enhancement/6741-adjust-beacon-timeout",
+    ```
 4. Remove `node_modules` directory and `package-lock.json` file.
 5. Run the command
-```
-npm install
-```
-
-You should see the targeted version of the beacon in your working directory `/node_modules/wp-rocket-scripts/dist`.
-
+    ```
+    npm install
+    ```
+    You should see the targeted version of the beacon in your working directory `/node_modules/wp-rocket-scripts/dist`.
 6. Use the gulp task there to generate the beacon script:
-```
-npm run gulp build:js:beacon
-```
-
-You should see the new beacon files in `assets/js`.
-
+    ```
+    npm run gulp build:js:beacon
+    ```
+    You should see the new beacon files in `assets/js`.
 7. Compile the plugin zip as usual.
 
-## How to release a new version
+### How to release a new version
 
 When a new WP Rocket release occurs with a new version of rocket-scripts, or when new developments are available on rocket-scripts develop without breaking compatibility with WP Rocket, a new rocket-scripts version must be created. To do so:
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,0 @@
-'use strict';
-const Beacon = require("./src/BeaconManager.js");
-
-module.exports = BeaconManager;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+'use strict';
+const Beacon = require("./src/BeaconManager.js");
+
+module.exports = BeaconManager;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-'use strict';
-const Beacon = require("./src/BeaconManager.js");
-module.exports = BeaconManager;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.4",
   "description": "Rocket main scripts packages",
   "type": "module",
-  "main": "index.js",
+  "main": "./src/BeaconEntryPoint.js",
   "directories": {
     "test": "tests"
   },

--- a/src/BeaconEntryPoint.js
+++ b/src/BeaconEntryPoint.js
@@ -21,4 +21,4 @@ import BeaconManager from "./BeaconManager.js";
     });
 } )( window.rocket_beacon_data );
 
-module.exports = BeaconManager;
+export default BeaconManager;

--- a/src/BeaconEntryPoint.js
+++ b/src/BeaconEntryPoint.js
@@ -20,3 +20,5 @@ import BeaconManager from "./BeaconManager.js";
         }, rocket_beacon_data.delay);
     });
 } )( window.rocket_beacon_data );
+
+module.exports = BeaconManager;

--- a/src/BeaconLcp.js
+++ b/src/BeaconLcp.js
@@ -207,7 +207,7 @@ class BeaconLcp {
             elementInfo.type === "picture";
 
         return (isImageOrVideo || isBgImageOrPicture) &&
-            this.performanceImages.some(item => item.src === elementInfo.src);
+          this.performanceImages.some(item => item.src === elementInfo.src);
     }
 
     getResults() {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -6,9 +6,9 @@ class BeaconUtils {
         const screenHeight = window.innerHeight || document.documentElement.clientHeight;
 
         const isNotValidForMobile = is_mobile &&
-            (screenWidth > threshold.width || screenHeight > threshold.height);
+          (screenWidth > threshold.width || screenHeight > threshold.height);
         const isNotValidForDesktop = !is_mobile &&
-            (screenWidth < threshold.width || screenHeight < threshold.height);
+          (screenWidth < threshold.width || screenHeight < threshold.height);
 
         return isNotValidForMobile || isNotValidForDesktop;
     }

--- a/test/BeaconLcp.test.js
+++ b/test/BeaconLcp.test.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import sinon from 'sinon';
 import BeaconLcp from '../src/BeaconLcp.js';
 import node_fetch from 'node-fetch';
 global.fetch = node_fetch;

--- a/test/BeaconManager.test.js
+++ b/test/BeaconManager.test.js
@@ -191,7 +191,9 @@ describe('BeaconManager', function() {
             // Spy on clearTimeout to ensure it's called
             clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
             // Mock the infiniteLoopId to simulate a timeout being set
-            beacon.infiniteLoopId = setTimeout(() => {}, 1000);
+            beacon.infiniteLoopId = setTimeout(() => {
+                throw new Error('Timeout during test.');
+            }, 10000);
         });
 
         afterEach(function() {
@@ -214,7 +216,7 @@ function formDataToObject(formData) {
     const object = {};
     formData.forEach((value, key) => {
         // Check if the object already contains the key
-        if (object.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(object, key)) {
             // If it's an array, push the new value
             if (Array.isArray(object[key])) {
                 object[key].push(value);

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import sinon from 'sinon';
 import BeaconUtils from '../src/Utils.js';
 import node_fetch from 'node-fetch';
 global.fetch = node_fetch;


### PR DESCRIPTION
# Description

Follow-up of #12 and needed for auto build in WP Rocket: we don't use index.js anymore as the entry point, but we use BeaconEntryPoint.js. So a few things must be adapted so that npm knows it and install the right files.

## Documentation

### User documentation

NA

### Technical documentation

NA

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
NA

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.
