### PR TITLE
Closes #31: Add a check if page is scrolled down.

### DIFF
--- a/src/BeaconManager.js
+++ b/src/BeaconManager.js
@@ -22,6 +22,12 @@ class BeaconManager {
             return;
         }
 
+        if (this._isPageScrolled()) {
+            this.logger.logMessage('Bailing out because the page has been scrolled');
+            this._finalize();
+            return;
+        }
+
         this.infiniteLoopId = setTimeout(() => {
             this._handleInfiniteLoop();
         }, 10000);
@@ -141,6 +147,10 @@ class BeaconManager {
 
     _handleInfiniteLoop() {
         this._saveFinalResultIntoDB();
+    }
+
+    _isPageScrolled() {
+        return window.pageYOffset > 0 || document.documentElement.scrollTop > 0;
     }
 
     _finalize() {

--- a/src/BeaconManager.js
+++ b/src/BeaconManager.js
@@ -22,7 +22,7 @@ class BeaconManager {
             return;
         }
 
-        if (this._isPageScrolled()) {
+        if (BeaconUtils.isPageScrolled()) {
             this.logger.logMessage('Bailing out because the page has been scrolled');
             this._finalize();
             return;
@@ -147,10 +147,6 @@ class BeaconManager {
 
     _handleInfiniteLoop() {
         this._saveFinalResultIntoDB();
-    }
-
-    _isPageScrolled() {
-        return window.pageYOffset > 0 || document.documentElement.scrollTop > 0;
     }
 
     _finalize() {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -35,6 +35,10 @@ class BeaconUtils {
         );
     }
 
+    static isPageScrolled() {
+        return window.pageYOffset > 0 || document.documentElement.scrollTop > 0;
+    }
+
 }
 
 export default BeaconUtils;


### PR DESCRIPTION
# Description

Fixes #31 
This PR adds a check to ensure that the beacon is not fired if the page is scrolled down before it runs. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

- Use - https://gist.github.com/DahmaniAdame/bd58d4be051f5995aa2318d341eb342a
- Scroll to the last image
- Hit refresh while making sure the beacon runs
- See the LCP image will be related to the current viewport

## Technical description

### Documentation

The `_isPageScrolled()` method is used in `BeaconManager.js` to check if the page is scrolled and bails out if it returns true. In-build test have been added as well.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)