### PR TITLE
Closes #6728 Largest element with a background-image that is not kept

### DIFF
--- a/src/BeaconLcp.js
+++ b/src/BeaconLcp.js
@@ -153,6 +153,10 @@ class BeaconLcp {
                 element_info.bg_set = matches.map(m => m[1] ? { src: m[1].trim() } : {});
             }
 
+            if (element_info.bg_set.length <= 0) {
+                return null;
+            }
+
             if (element_info.bg_set.length > 0) {
                 element_info.src = element_info.bg_set[0].src;
                 if (element_info.type === "bg-img-set") {
@@ -165,7 +169,9 @@ class BeaconLcp {
     }
 
     _initWithFirstElementWithInfo(elements) {
-        const firstElementWithInfo = elements.find(item => item.elementInfo !== null);
+        const firstElementWithInfo = elements.find(item => {
+            return item.elementInfo !== null && (item.elementInfo.src || item.elementInfo.srcset);
+        });
 
         if (!firstElementWithInfo) {
             this.logger.logMessage("No LCP candidate found.");

--- a/test/BeaconLcp.test.js
+++ b/test/BeaconLcp.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import BeaconLcp from '../src/BeaconLcp.js';
 import node_fetch from 'node-fetch';
+import sinon from 'sinon';
 global.fetch = node_fetch;
 
 describe('BeaconManager', function() {
@@ -12,6 +13,29 @@ describe('BeaconManager', function() {
         mockLogger = { logMessage: function(message) {} };
 
         beacon = new BeaconLcp(config, mockLogger);
+
+        global.window = {};
+        global.document = {};
+
+        global.window.getComputedStyle = sinon.stub().returns({
+            getPropertyValue: sinon.stub().returns('none'),
+        });
+
+        global.getComputedStyle = (element, pseudoElement) => {
+            return {
+                getPropertyValue: (prop) => {
+                    if (prop === "background-image") {
+                        return "none";
+                    }
+                    return "";
+                }
+            };
+        };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        delete global.window;
     });
 
     describe('#constructor()', function() {
@@ -58,6 +82,18 @@ describe('BeaconManager', function() {
             beacon._initWithFirstElementWithInfo(elements);
 
             assert.strictEqual(beacon.performanceImages.length, 0);
+        });
+    });
+
+    describe('#_getElementInfo()', function() {
+        it('should return null when there are no valid background images', function() {
+            const element = {
+                nodeName: 'div'
+            };
+
+            const elementInfo = beacon._getElementInfo(element);
+
+            assert.strictEqual(elementInfo, null);
         });
     });
 });


### PR DESCRIPTION
# Description
Fixed the issue with LCP when background-image has gradient 

Fixes https://github.com/wp-media/wp-rocket/issues/6728


## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
Check scenario [here](https://github.com/wp-media/wp-rocket/issues/6728) 

## Technical description
Improve the beaconLCP script to capture valid image after background-image gradient.

### Documentation

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.