### PR TITLE
Closes #34: exclude svg use from lrc

### DIFF
--- a/src/BeaconLrc.js
+++ b/src/BeaconLrc.js
@@ -23,12 +23,23 @@ class BeaconLrc {
 
     _getLazyRenderElements() {
         const elements = document.querySelectorAll('[data-rocket-location-hash]');
+        const svgUseTargets = this._getSvgUseTargets();
 
         if (elements.length <= 0) {
             return [];
         }
 
-        const validElements = Array.from(elements).filter(element => !this._skipElement(element));
+        const validElements = Array.from(elements).filter(element => {
+            if (this._skipElement(element)) {
+                return false;
+            }
+            if (svgUseTargets.includes(element)) {
+                this.logger.logColoredMessage(`Element skipped because of SVG: ${element.tagName}`, 'orange');
+                return false;
+            }
+            return true;
+        });
+
 
         return validElements.map(element => ({
             element: element,
@@ -133,6 +144,21 @@ class BeaconLrc {
         return element.hasAttribute('data-rocket-location-hash')
             ? element.getAttribute('data-rocket-location-hash')
             : 'No hash detected';
+    }
+
+    _getSvgUseTargets() {
+        const useElements = document.querySelectorAll('use');
+        const targets = new Set();
+
+        useElements.forEach(use => {
+            let parent = use.parentElement;
+            while (parent && parent !== document.body) {
+                targets.add(parent);
+                parent = parent.parentElement;
+            }
+        });
+
+        return Array.from(targets);
     }
 
     getResults() {

--- a/test/BeaconLrc.test.js
+++ b/test/BeaconLrc.test.js
@@ -53,7 +53,7 @@ describe('BeaconLrc', function() {
         // Mocking document.querySelectorAll
         global.document = {
             querySelectorAll: (selector) => {
-                if (selector === '[data-rocket-location-hash]') {
+                if (selector === '[data-rocket-location-hash]' || selector === 'use') {
                     return mockElements;
                 }
                 return [];
@@ -246,5 +246,15 @@ describe('BeaconLrc', function() {
         assert.strictEqual(beaconLrc._getXPath({id: 'testID'}), '//*[@id="testID"]');
 
         _getElementXPathStub.restore();
+    });
+
+    it('should return the correct SVG use target elements', function() {
+        mockElements[0].parentElement = { tagName: 'svg', parentElement: null };
+        mockElements[1].parentElement = { tagName: 'div', parentElement: null };
+
+        const targets = beaconLrc._getSvgUseTargets();
+        assert.strictEqual(targets.length, 2);
+        assert.strictEqual(targets[0].tagName, 'svg');
+        assert.strictEqual(targets[1].tagName, 'div');
     });
 });

--- a/test/BeaconLrc.test.js
+++ b/test/BeaconLrc.test.js
@@ -132,6 +132,21 @@ describe('BeaconLrc', function() {
         _skipElementStub.restore();
     });
 
+    it('should skip elements with svg use', function() {
+        const _getElementDepthStub = sinon.stub(beaconLrc, '_getElementDepth');
+        _getElementDepthStub.returns(1);
+
+        const _svgElementStub = sinon.stub(beaconLrc, '_getSvgUseTargets');
+        _svgElementStub.returns([mockElements[2]]);
+
+        const elements = beaconLrc._getLazyRenderElements();
+        const skippedElement = elements.find(el => el.hash === 'hash3'); 
+        assert.strictEqual(skippedElement, undefined);
+
+        _getElementDepthStub.restore();
+        _svgElementStub.restore();
+    });
+
     it('should return correct distance', () => {
         const distance = beaconLrc._getElementDistance(mockElements[2]);
         assert.strictEqual(distance, 600);


### PR DESCRIPTION
# Description

Fixes #34 

We are adding a `_getSvgUseTargets` function to `BeaconLrc` so we can detect `svg use` and avoid processing them. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Refer to https://github.com/wp-media/wp-rocket/issues/6978
## Technical description

### Documentation

**Purpose**: The method gathers all parent elements of <use> elements in the document. This is useful for operations that need to affect or be aware of the entire SVG hierarchy.
**Implementation:**
It first selects all <use> elements in the document.
For each <use> element, it traverses up the DOM tree, collecting each parent element until it reaches the <body>.
It uses a Set to ensure that each parent element is collected only once.
Finally, it returns an array of these parent elements.

### New dependencies
None

### Risks
None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
