### PR TITLE
Fixes 7326: 3.19-prealpha: Same preloaded font URL is added twice to DB preload fonts table

### DIFF
--- a/src/BeaconPreloadFonts.js
+++ b/src/BeaconPreloadFonts.js
@@ -204,7 +204,7 @@ class BeaconPreloadFonts {
                     processElementFont(window.getComputedStyle(element, pseudo), pseudo);
                 });
             } catch (e) {
-                console.debug('Error processing element:', e);
+                this.logger.logMessage('Error processing element:', e);
             }
         });
 
@@ -219,7 +219,7 @@ class BeaconPreloadFonts {
         }
 
         this.logger.logMessage('Above the fold fonts:', aboveTheFoldFonts);
-        this.aboveTheFoldFonts = Object.values(aboveTheFoldFonts.allFonts).flatMap(font => font.variations.map(variation => variation.url));
+        this.aboveTheFoldFonts = [...new Set(Object.values(aboveTheFoldFonts.allFonts).flatMap(font => font.variations.map(variation => variation.url)))];
     }
 
     /**

--- a/test/BeaconPreloadFonts.test.js
+++ b/test/BeaconPreloadFonts.test.js
@@ -289,4 +289,39 @@ describe('BeaconPreloadFonts', () => {
             window.getComputedStyle.restore();
         });
     });
+
+    describe('getResults', () => {
+        it('should return an array with no duplicate URLs from getResults', async () => {
+            sinon.stub(beaconPreloadFonts, 'getNetworkLoadedFonts').returns(new Map());
+            sinon.stub(beaconPreloadFonts, 'getFontFaceRules').returns({});
+            sinon.stub(beaconPreloadFonts, 'processExternalFonts').returns({});
+    
+            // Stub the summarizeMatches method to control its output
+            const summarizeMatchesStub = sinon.stub(beaconPreloadFonts, 'summarizeMatches').returns({
+                externalFonts: {},
+                hostedFonts: {},
+                allFonts: {
+                    'Font1': {
+                        variations: [{ url: 'https://example.com/font1.woff2' }],
+                    },
+                    'Font2': {
+                        variations: [{ url: 'https://example.com/font2.woff2' }],
+                    },
+                    'Font3': {
+                        variations: [{ url: 'https://example.com/font1.woff2' }], // Duplicate URL
+                    },
+                }
+            });
+    
+            await beaconPreloadFonts.run();
+            const results = beaconPreloadFonts.getResults();
+            
+            // Check for duplicates
+            const uniqueResults = [...new Set(results)];
+            assert.deepEqual(results, uniqueResults, 'The results contain duplicate URLs');
+    
+            // Restore the stub
+            summarizeMatchesStub.restore();
+        });
+    });
 });


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket/issues/7326
Fixes issues with same font urls added multiple times in DB

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
## Detailed scenario

### What was tested
Tested that the beacon did not send duplicate urls to DB.
Tested both Manually and Automated.

### How to test

- Visit a template setup like this [one](https://new.rocketlabsqa.ovh/preloadfont_fonticons)
- Check DB and see that only one entry is there.
![Screenshot 2025-02-25 at 00 12 58](https://github.com/user-attachments/assets/828d9821-b339-4e0e-9bad-6e269f5ef4de)

## Technical description

### Documentation

Used `Set` to create unique entries.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

