### PR TITLE
Fixes issue where font url is not detected in some template

### DIFF
--- a/src/BeaconPreloadFonts.js
+++ b/src/BeaconPreloadFonts.js
@@ -168,6 +168,8 @@ class BeaconPreloadFonts {
      * @returns {Promise<void>} A promise that resolves when the analysis is complete.
      */
     async run() {
+        // Wait for fonts to be loaded
+        await document.fonts.ready;
         const networkLoadedFonts = this.getNetworkLoadedFonts();
         const stylesheetFonts = this.getFontFaceRules();
         const hostedFonts = new Map();

--- a/test/BeaconPreloadFonts.test.js
+++ b/test/BeaconPreloadFonts.test.js
@@ -48,7 +48,10 @@ describe('BeaconPreloadFonts', () => {
                     getBoundingClientRect: () => ({ top: 50, height: 100, width: 100 }) // Mocking getBoundingClientRect
                 }
             ]),
-            documentElement: { scrollTop: 100 } // Mock scroll position
+            documentElement: { scrollTop: 100 }, // Mock scroll position
+            fonts: {
+                ready: function () {}
+            }
         };
 
         // Mocking the DOM elements and their styles


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket/issues/7341

This PR fixes an issue with font url not detected on locally hosted font css containing external font urls.

## Type of change
- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Same step [here](https://github.com/wp-media/wp-rocket/issues/7341#issue-2885324627)

### How to test

Follow the steps [here](https://github.com/wp-media/wp-rocket/issues/7341#issue-2885324627)

## Technical description

### Documentation

In this PR, we wait for fonts to fully load before we start processing using `await document.fonts.ready`

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
