### PR TITLE
Fixes issue with fonts used inside inline internal style are not preloaded

### DIFF
--- a/src/BeaconPreloadFonts.js
+++ b/src/BeaconPreloadFonts.js
@@ -95,8 +95,6 @@ class BeaconPreloadFonts {
         const stylesheetFonts = {};
 
         Array.from(document.styleSheets).forEach((sheet) => {
-          // Check if the stylesheet is from the same domain
-          if (sheet.href && new URL(sheet.href).origin !== window.location.origin) return;
             try {
                 Array.from(sheet.cssRules || []).forEach((rule) => {
                     if (rule instanceof CSSFontFaceRule) {
@@ -116,10 +114,12 @@ class BeaconPreloadFonts {
                         
                         const urls = src.match(/url\(['"]?([^'"]+)['"]?\)/g) || [];
                         urls.forEach((urlMatch) => {
-                            const rawUrl = urlMatch.match(/url\(['"]?([^'"]+)['"]?\)/)[1];
-                            // Reconstruct url to absolute
-                            const url = new URL(rawUrl, sheet.href).href;
-                            const normalizedUrl = this.cleanUrl(url);
+                            let rawUrl = urlMatch.match(/url\(['"]?([^'"]+)['"]?\)/)[1];
+                            // Reconstruct url to absolute if stylesheet is not internal.
+                            if (sheet.href) {
+                                rawUrl = new URL(rawUrl, sheet.href).href;
+                            }
+                            const normalizedUrl = this.cleanUrl(rawUrl);
                             if (!stylesheetFonts[fontFamily].urls.includes(normalizedUrl)) {
                                 stylesheetFonts[fontFamily].urls.push(normalizedUrl);
                                 stylesheetFonts[fontFamily].variations.add(JSON.stringify({

--- a/test/BeaconPreloadFonts.test.js
+++ b/test/BeaconPreloadFonts.test.js
@@ -2,6 +2,27 @@ import assert from 'assert';
 import sinon from 'sinon';
 import BeaconPreloadFonts from '../src/BeaconPreloadFonts.js';
 
+// Helper function to create mock CSSFontFaceRule objects
+const createMockFontFaceRule = (fontFamily, src, weight, style) => {
+    // Create an actual instance that passes the instanceof check
+    const rule = Object.create(CSSFontFaceRule.prototype);
+    
+    // Add the style property with getPropertyValue method
+    rule.style = {
+      getPropertyValue: function(prop) {
+        switch(prop) {
+          case 'font-family': return `'${fontFamily}'`;
+          case 'src': return src;
+          case 'font-weight': return weight;
+          case 'font-style': return style;
+          default: return '';
+        }
+      }
+    };
+    
+    return rule;
+  }
+
 describe('BeaconPreloadFonts', () => {
     let beaconPreloadFonts;
     let loggerMock;
@@ -53,6 +74,8 @@ describe('BeaconPreloadFonts', () => {
                 ready: function () {}
             }
         };
+
+        global.CSSFontFaceRule = function() {};
 
         // Mocking the DOM elements and their styles
         document.body.innerHTML = `
@@ -326,5 +349,122 @@ describe('BeaconPreloadFonts', () => {
             // Restore the stub
             summarizeMatchesStub.restore();
         });
+    });
+
+    describe('getFontFaceRules', () => {
+        it('should return an empty object when no stylesheets exist', function() {
+            document.styleSheets = [];
+            const result = beaconPreloadFonts.getFontFaceRules();
+            assert.deepStrictEqual(result, {});
+        });
+        
+        it('should process multiple font-face rules correctly', function() {
+            // Create mock stylesheets with font-face rules
+            const mockCSSFontFaceRule1 = createMockFontFaceRule('Roboto', 'url("fonts/roboto.woff2")', '700', 'normal');
+            const mockCSSFontFaceRule2 = createMockFontFaceRule('Roboto', 'url("fonts/roboto-italic.woff2")', '700', 'italic');
+            const mockCSSFontFaceRule3 = createMockFontFaceRule('Open Sans', 'url("fonts/opensans.woff2")', '400', 'normal');
+            
+            const mockStyleSheet = {
+                href: 'https://example.com/styles.css',
+                cssRules: [
+                mockCSSFontFaceRule1,
+                { type: 1 }, // Some other rule type
+                mockCSSFontFaceRule2,
+                mockCSSFontFaceRule3
+                ]
+            };
+            
+            document.styleSheets = [mockStyleSheet];
+
+            beaconPreloadFonts.cleanUrl = sinon.stub().callsFake(url => url.split('?')[0]);
+            
+            const result = beaconPreloadFonts.getFontFaceRules();
+            console.log('result', result);
+            
+            // Verify correct parsing
+            assert.strictEqual(Object.keys(result).length, 2, 'Should have two font families');
+            
+            // Check Roboto data
+            assert.ok(result['Roboto'], 'Should have Roboto font');
+            assert.strictEqual(result['Roboto'].urls.length, 2, 'Roboto should have 2 URLs');
+            assert.strictEqual(result['Roboto'].variations.length, 2, 'Roboto should have 2 variations');
+            
+            // Check Open Sans data
+            assert.ok(result['Open Sans'], 'Should have Open Sans font');
+            assert.strictEqual(result['Open Sans'].urls.length, 1, 'Open Sans should have 1 URL');
+            
+            // Verify cleanUrl was called
+            assert.ok(beaconPreloadFonts.cleanUrl.called, 'cleanUrl should be called');
+        });
+        
+        it('should handle multiple src URLs in one font-face rule', function() {
+            const multipleSrcRule = createMockFontFaceRule(
+                'MyCustomFont3', 
+                'url("fonts/font.woff2") format("woff2"), url("fonts/font.woff") format("woff"), url("fonts/font.ttf") format("truetype")',
+                'normal',
+                'normal'
+            );
+            
+            document.styleSheets = [{
+                href: null,
+                cssRules: [multipleSrcRule]
+            }];
+            
+            const result = beaconPreloadFonts.getFontFaceRules();
+            
+            assert.ok(result['MyCustomFont3'], 'Should have MyCustomFont3');
+            assert.strictEqual(result['MyCustomFont3'].urls.length, 3, 'Should extract all 3 URLs');
+        });
+        
+        it('should convert relative URLs to absolute when stylesheet has href', function() {
+            const fontFaceRule = createMockFontFaceRule('Arial', 'url("../fonts/arial.woff2")', '400', 'normal');
+            
+            document.styleSheets = [{
+                href: 'https://example.com/css/styles.css',
+                cssRules: [fontFaceRule]
+            }];
+            
+            global.URL = sinon.stub().returns({
+                href: 'https://example.com/fonts/arial.woff2'
+            });
+            
+            const result = beaconPreloadFonts.getFontFaceRules();
+            
+            assert.strictEqual(result['Arial'].urls[0], 'https://example.com/fonts/arial.woff2', 
+                                'Should convert relative URL to absolute');
+        });
+        
+        it('should handle errors when accessing cross-origin stylesheets', function() {
+            // Create a stylesheet that throws error when accessing cssRules
+            const errorStyleSheet = {
+                get cssRules() {
+                throw new Error('Cannot access cssRules of cross-origin stylesheet');
+                }
+            };
+            
+            document.styleSheets = [errorStyleSheet];
+            
+            const result = beaconPreloadFonts.getFontFaceRules();
+            
+            // Should log error and return empty object
+            assert.ok(beaconPreloadFonts.logger.logMessage.called, 'Should log the error');
+            assert.deepStrictEqual(result, {}, 'Should return empty object on error');
+        });
+        
+        it('should deduplicate URLs for the same font family', function() {
+            // Create two rules with DIFFERENT URLs
+            const rule1 = createMockFontFaceRule('Duplicate', 'url("fonts/normal.woff2")', '400', 'normal');
+            const rule2 = createMockFontFaceRule('Duplicate', 'url("fonts/bold.woff2")', '700', 'normal');
+            
+            document.styleSheets = [{
+              href: null,
+              cssRules: [rule1, rule2]
+            }];
+            
+            const result = beaconPreloadFonts.getFontFaceRules();
+            
+            assert.strictEqual(result['Duplicate'].urls.length, 2, 'Should have two different URLs');
+            assert.strictEqual(result['Duplicate'].variations.length, 2, 'Should have two variations');
+          });
     });
 });


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket/issues/7327
Fixes issue with fonts not detected with internal and inline styling.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Automated Tests & Manual Test:
Add a font face internal and use the font face in internal style for an above the fold element and see if it's detected by the beacon.

### How to test
Follow steps [here](https://github.com/wp-media/wp-rocket/issues/7327#issue-2874342042)

## Technical description

### Documentation

Reconstruct url to absolute only if stylesheet is not internal.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
