### PR TITLE
Closes #49: otf and eot fonts shouldn't be processed by default with preload fonts

### DIFF
--- a/src/BeaconPreloadFonts.js
+++ b/src/BeaconPreloadFonts.js
@@ -4,9 +4,14 @@ class BeaconPreloadFonts {
         this.config = config;
         this.logger = logger;
         this.aboveTheFoldFonts = [];
+        // Use processed_extensions from config if set, otherwise default to ["woff", "woff2", "ttf"].
+        const extensions = (Array.isArray(this.config.processed_extensions) && this.config.processed_extensions.length > 0
+            ? this.config.processed_extensions
+            : ["woff", "woff2", "ttf"])
+            .map(ext => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+            .join('|');
+        this.FONT_FILE_REGEX = new RegExp(`\\.(${extensions})(\\?.*)?$`, 'i');
     }
-
-    static FONT_FILE_REGEX = /\.(woff2?|ttf|otf|eot)(\?.*)?$/i;
 
     /**
      * Checks if a given font family is a system font.
@@ -75,8 +80,8 @@ class BeaconPreloadFonts {
     getNetworkLoadedFonts() {
         return new Map(
             window.performance
-                .getEntriesByType('resource')
-                .filter((resource) => BeaconPreloadFonts.FONT_FILE_REGEX.test(resource.name))
+                .getEntriesByType("resource")
+                .filter((resource) => this.FONT_FILE_REGEX.test(resource.name))
                 .map((resource) => [this.cleanUrl(resource.name), resource.name])
         );
     }


### PR DESCRIPTION
# Description

Fixes #49
The list of font extensions processed will now be dynamically coming from WP Rocket filter rather than a static value.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

The value is coming from the variable in the page. If we can't get it, then we have default values.

### How to test

Please run with https://github.com/wp-media/wp-rocket/pull/7318 to have the actual variable being added to the html

## Technical description

### Documentation

This pull request updates the `BeaconPreloadFonts` class to allow configurable font file extensions and improves the flexibility of font file detection. The most important changes include replacing the static `FONT_FILE_REGEX` with an instance-specific regex based on the configuration and updating font-loading logic to use the new regex.

### Updates to font file detection:

* [`src/BeaconPreloadFonts.js`](diffhunk://#diff-2604b2fd59254542b65254d68b26f17a1ccae4873a61e4e2392edc00a043d013R7-L10): Replaced the static `FONT_FILE_REGEX` with an instance-specific regex (`this.FONT_FILE_REGEX`) that is dynamically generated based on the `processed_extensions` configuration. If no configuration is provided, it defaults to `["woff", "woff2", "ttf"]`. This change ensures greater flexibility in specifying font file extensions.

* [`src/BeaconPreloadFonts.js`](diffhunk://#diff-2604b2fd59254542b65254d68b26f17a1ccae4873a61e4e2392edc00a043d013L78-R84): Updated the `getNetworkLoadedFonts` method to use the instance-specific `this.FONT_FILE_REGEX` instead of the removed static `FONT_FILE_REGEX`. This aligns the method with the new customizable regex logic.
### New dependencies

None
### Risks

None
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No test for that