### PR TITLE
Fixes https://github.com/wp-media/wp-rocket/issues/7388

### DIFF
--- a/src/BeaconPreconnectExternalDomain.js
+++ b/src/BeaconPreconnectExternalDomain.js
@@ -46,7 +46,7 @@ class BeaconPreconnectExternalDomain {
 
             if (this.isExternalDomain(url)) {
                 this.matchedItems.add(`${url.hostname}-${el.tagName.toLowerCase()}`);
-                this.result = [...new Set(this.result.concat(url.hostname))];
+                this.result = [...new Set(this.result.concat(url.origin))];
             }
         } catch (e) {
             this.logger.logMessage(e);


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket/issues/7388
Stores the domain name with the protocol in the final result instead of just the domain

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Checked that preconnected domains are having the same protocol as the original urls.

### How to test

- Visit a page with external domains having https protocol
- Clear cache
- Re-visit page and see that preconnected domains have the same protocol as original urls.

## Technical description

### Documentation
Get the url domain with the protocol using the `origin` property instead of just getting the domain alone with `hostname`

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
