### PR TITLE
Closes #7391: FileNotFound is preloaded for some page templates

### DIFF
--- a/src/BeaconPreloadFonts.js
+++ b/src/BeaconPreloadFonts.js
@@ -506,22 +506,6 @@ class BeaconPreloadFonts {
                     const aboveElements = elements.filter(el => this.isElementAboveFold(el));
                     const belowElements = elements.filter(el => !this.isElementAboveFold(el));
 
-                    if (!allFonts[fontFamily]) {
-                        allFonts[fontFamily] = {
-                            type: 'hosted',
-                            variations: [],
-                            elementCount: {
-                                aboveFold: aboveElements.length,
-                                belowFold: belowElements.length,
-                                total: elements.length
-                            },
-                            urlCount: {
-                                aboveFold: new Set(),
-                                belowFold: new Set()
-                            }
-                        };
-                    }
-
                     data.variations.forEach(variation => {
                         let matchingUrl = null;
                         for (const styleUrl of data.urls) {
@@ -532,20 +516,37 @@ class BeaconPreloadFonts {
                             }
                         }
 
-                        // Add variation with correct element counts
-                        allFonts[fontFamily].variations.push({
-                            weight: variation.weight,
-                            style: variation.style,
-                            url: matchingUrl || 'File not found',
-                            elementCount: {
-                                aboveFold: aboveElements.length,
-                                belowFold: belowElements.length,
-                                total: elements.length
-                            }
-                        });
-
                         // Track URLs per location
                         if (matchingUrl) {
+                            // Only create new object if a valid matching url exist in network loaded fonts.
+                            if (!allFonts[fontFamily]) {
+                                allFonts[fontFamily] = {
+                                    type: 'hosted',
+                                    variations: [],
+                                    elementCount: {
+                                        aboveFold: aboveElements.length,
+                                        belowFold: belowElements.length,
+                                        total: elements.length
+                                    },
+                                    urlCount: {
+                                        aboveFold: new Set(),
+                                        belowFold: new Set()
+                                    }
+                                };
+                            }
+
+                            // Add variation with correct element counts
+                            allFonts[fontFamily].variations.push({
+                                weight: variation.weight,
+                                style: variation.style,
+                                url: matchingUrl,
+                                elementCount: {
+                                    aboveFold: aboveElements.length,
+                                    belowFold: belowElements.length,
+                                    total: elements.length
+                                }
+                            });
+
                             if (aboveElements.length > 0) {
                                 allFonts[fontFamily].urlCount.aboveFold.add(matchingUrl);
                             }
@@ -559,12 +560,14 @@ class BeaconPreloadFonts {
                         return;
                     }
 
-                    // Copy to hostedFontsResults
-                    hostedFontsResults[fontFamily] = {
-                        variations: allFonts[fontFamily].variations,
-                        elementCount: { ...allFonts[fontFamily].elementCount },
-                        urlCount: { ...allFonts[fontFamily].urlCount },
-                    };
+                    if (allFonts[fontFamily]) {
+                        // Copy to hostedFontsResults
+                        hostedFontsResults[fontFamily] = {
+                            variations: allFonts[fontFamily].variations,
+                            elementCount: { ...allFonts[fontFamily].elementCount },
+                            urlCount: { ...allFonts[fontFamily].urlCount },
+                        };
+                    }
                 }
             });
         }


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket/issues/7391
Fixes the issue when plugin preloads string 'file not found' on page.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Check that with specific templates, file not found is added to the db and then preloaded.

### How to test

- Test on page using this template: https://github.com/wp-media/rocket-test-data/blob/master/templates/preloadfonts_differentformatsdebug.php
- Check that 'File not found' is not saved to DB and and preloaded on page.

## Technical description

### Documentation

Updated the logic to only push new font variations when there is a valid matching url: https://github.com/wp-media/rocket-scripts/blob/834d8d01902ba313b9e468e130425c4e696d4571/src/BeaconPreloadFonts.js#L520-L536
This eliminates the need to add a default value assignment directly in the object which in this case is `File not found`

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
